### PR TITLE
Update revision of hazelcast-go-client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -46,7 +46,7 @@
     "serialization",
     "serialization/classdef"
   ]
-  revision = "57b5e47611af979ddc50b1f628bb38c7d44db0d4"
+  revision = "f4abe3be43f52f9aaeb48d3321050a13cf8b013a"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"


### PR DESCRIPTION
Fixes #3 

Looks like this error is connected with https://github.com/hazelcast/hazelcast-go-client/issues/242 which was fixed in https://github.com/hazelcast/hazelcast-go-client/pull/244

Based on my fast testing it does not break anything else.
Maintainer might consider using a bit younger version of hazelcast-go-client but I decided to select first working version.